### PR TITLE
[#2]: Improve the publish pipeline

### DIFF
--- a/.github/workflows/build-and-publish.yml
+++ b/.github/workflows/build-and-publish.yml
@@ -1,6 +1,9 @@
 name: Build and publish Fellowship to PyPI and TestPyPI
 
-on: push
+on:
+  push
+  branches:
+    - master
 
 jobs:
   build-n-publish:
@@ -21,6 +24,7 @@ jobs:
       - name: Build a binary wheel and a source tarball
         run: python setup.py sdist
       - name: Publish distribution to Test PyPI
+        if: "!startsWith(github.ref, 'refs/tags')"
         uses: pypa/gh-action-pypi-publish@master
         with:
           password: ${{ secrets.TEST_PYPI_FELLOWSHIP_TOKEN }}

--- a/README.rst
+++ b/README.rst
@@ -90,3 +90,6 @@ The code and the issues are hosted on `GitHub
 
 The project is licensed under `BSD-3-Clause
 <https://github.com/nokia/contract-test-framework/blob/main/LICENSE>`_.
+
+The documentation is hosted on `read_the_docs
+<https://contract-test-framework.readthedocs.io/en/latest/?>`_

--- a/fellowship/_version.py
+++ b/fellowship/_version.py
@@ -2,4 +2,4 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-__version__ = '0.0.1'
+__version__ = '0.0.2'


### PR DESCRIPTION
Update publish pipeline to only trigger when publishing to master.
Changed also policy to:
TestPyPI is the target when no tags are pushed and PyPI when pushed with tags.