### PR TITLE
[#14]: Clear grpc cache if service is not found

### DIFF
--- a/fellowship/_version.py
+++ b/fellowship/_version.py
@@ -2,4 +2,4 @@
 # Licensed under the BSD 3-Clause License.
 # SPDX-License-Identifier: BSD-3-Clause
 
-__version__ = '0.1.0'
+__version__ = '0.1.1'


### PR DESCRIPTION
New method that checks if the gRPC cache contains the service endpoint before making request.

Fixes problem when a gRPC server consisted of several different packages. 
Since when doing a stub request only one package is loaded at a time and thus it cannot find the correct service from the cache. Solution is to reset cache if the service is not found